### PR TITLE
Fixed key adding when tool belt is full

### DIFF
--- a/scripts/virtualGarage/player_getVehicle.sqf
+++ b/scripts/virtualGarage/player_getVehicle.sqf
@@ -47,12 +47,16 @@ if (PVDZE_spawnVehicleResult != "0") then {
 	_inventory = weapons player;
 	dayz_myBackpack = unitBackpack player;
 	if (!isNull dayz_myBackpack) then {_backPack = (getWeaponCargo dayz_myBackpack) select 0;};
-	if (_keyID in (_inventory+_backPack)) then {
-		if (_keyID in _inventory) then {format[localize "STR_VG_IN_INVENTORY",_keyName] call dayz_rollingMessages;};
-		if (_keyID in _backPack) then {format[localize "STR_VG_IN_BACKPACK",_keyName] call dayz_rollingMessages;};
+	if !(isClass(configFile >> "CfgWeapons" >> _keyID)) then {
+		if (_keyID in (_inventory+_backPack)) then {
+			if (_keyID in _inventory) then {format[localize "STR_VG_IN_INVENTORY",_keyName] call dayz_rollingMessages;};
+			if (_keyID in _backPack) then {format[localize "STR_VG_IN_BACKPACK",_keyName] call dayz_rollingMessages;};
+		} else {
+			player addWeapon _keyID;
+			format[localize "STR_VG_ADDED_INVENTORY",_keyName] call dayz_rollingMessages;
+		};
 	} else {
-		player addWeapon _keyID;
-		format[localize "STR_VG_ADDED_INVENTORY",_keyName] call dayz_rollingMessages;
+		localize "str_epoch_player_107" call dayz_rollingMessages;
 	};
 };
 

--- a/scripts/virtualGarage/player_getVehicle.sqf
+++ b/scripts/virtualGarage/player_getVehicle.sqf
@@ -54,6 +54,7 @@ if (PVDZE_spawnVehicleResult != "0") then {
 		} else {
 			player addWeapon _keyID;
 			format[localize "STR_VG_ADDED_INVENTORY",_keyName] call dayz_rollingMessages;
+			localize "STR_VG_VEHICLE_SPAWNED" call dayz_rollingMessages;
 		};
 	} else {
 		localize "str_epoch_player_107" call dayz_rollingMessages;
@@ -63,5 +64,3 @@ if (PVDZE_spawnVehicleResult != "0") then {
 PVDZE_spawnVehicle = nil;
 PVDZE_spawnVehicleResult = nil;
 vg_vehicleList = nil;
-
-localize "STR_VG_VEHICLE_SPAWNED" call dayz_rollingMessages;


### PR DESCRIPTION
Fixes an issue where the key would be added to the player's inventory even if their inventory was full. Will now error out with "You do not have enough room on your toolbelt".